### PR TITLE
Edit install script to allow automatic updates.

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 ﻿$ErrorActionPreference = 'Stop'
 $checksum = '65A7FC311B272E4C11ED30FC343F5922E2D07F538B161EBE6E783A005A329370'
-$url = 'https://zoom.us/client/4.6.13610.1201/ZoomInstallerFull.msi'
+$url = 'https://www.zoom.us/client/latest/ZoomInstallerFull.msi'
 
 $packageArgs = @{
   packageName    = 'zoom'
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'msi'
   url            = $url
-  silentArgs     = '/quiet /norestart'
+  silentArgs     = '/quiet /norestart ZoomAutoUpdate="true"'
   validExitCodes = @(0)
   softwareName   = 'zoom*'
   checksum       = $checksum


### PR DESCRIPTION
This adds Zoom's new URL for getting the latest `.msi` automatically with no need for HTML parsing, and adds a silent argument to keep the client up to date.