### PR TITLE
Enable auto update for Zoom MSI auto zoom package.

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -8,7 +8,7 @@ $packageArgs = @{
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'msi'
   url            = $url
-  silentArgs     = '/quiet /norestart'
+  silentArgs     = '/quiet /norestart ZoomAutoUpdate=True'
   validExitCodes = @(0)
   softwareName   = 'zoom*'
   checksum       = $checksum


### PR DESCRIPTION
@mikecole I saw in the comments for the Zoom-client package that someone wanted Zoom's auto update functionality enabled for the MSI.   According the the documentation from Zoom this should enable that.

https://support.zoom.us/hc/en-us/articles/201362163-Mass-Installation-and-Configuration-for-Windows