### PR TITLE
Remove iconUrl and delist from Chocolatey

### DIFF
--- a/manual/zoom-client/zoom-client.nuspec
+++ b/manual/zoom-client/zoom-client.nuspec
@@ -16,7 +16,6 @@
       This version is deprecated. Please use **zoom** package.
     </description>
     <summary>Zoom unifies cloud video conferencing, simple online meetings, group messaging, and a software-defined conference room solution into one easy-to-use platform.</summary>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/zoom.png</iconUrl>
     <docsUrl>https://support.zoom.us/hc/en-us</docsUrl>
     <licenseUrl>http://zoom.us/pricing</licenseUrl>
     <bugTrackerUrl>https://support.zoom.us/hc/en-us/requests/new</bugTrackerUrl>


### PR DESCRIPTION
Hey,
I just noticed this deprecated package for Zoom was still listed on Chocolatey. It looks like it still needs to have the iconUrl removed and then be unlisted in your account settings so new users aren't confused per https://docs.chocolatey.org/en-us/community-repository/maintainers/deprecate-a-chocolatey-package.

You can unlist the package by going to:
Account > Manage My Packages > Click "Trash Icon" next to package name > Uncheck > Save