### PR TITLE
line: use the new download URL and update

### DIFF
--- a/automatic/line/line.nuspec
+++ b/automatic/line/line.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>line</id>
-    <version>6.3.2.2338</version>
+    <version>6.7.3.2508</version>
     <packageSourceUrl>https://github.com/mikecole/chocolatey-packages</packageSourceUrl>
     <owners>Mike Cole</owners>
     <title>LINE</title>

--- a/automatic/line/tools/chocolateyInstall.ps1
+++ b/automatic/line/tools/chocolateyInstall.ps1
@@ -1,11 +1,11 @@
-﻿$ErrorActionPreference = 'Stop'
-$checksum = '7453D2FFAEAABD24888E384D5E54332B6A82A376BD34B4B153D98A436942DCE6'
+$ErrorActionPreference = 'Stop'
+$checksum = '50ff2a34fec6fa9682daa32ef22df68c165ea4ec7f7704c57bb81e08d72fa5c1'
 
 $packageArgs = @{
   packageName    = 'line'
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'exe'
-  url            = 'http://dl.desktop.line.naver.jp/naver/LINE/win/LineInst.exe'
+  url            = 'https://desktop.line-scdn.net/win/new/LineInst.exe'
   silentArgs     = '/S'
   validExitCodes = @(0)
   softwareName   = 'Line*'

--- a/automatic/line/update.ps1
+++ b/automatic/line/update.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 import-module au
 
-$url = 'http://dl.desktop.line.naver.jp/naver/LINE/win/LineInst.exe'
+$url = 'https://desktop.line-scdn.net/win/new/LineInst.exe'
 
 function global:au_SearchReplace {
     @{


### PR DESCRIPTION
The download URL can be found at the bottom of https://line.me/en/

Somehow with the latest au module (v2020.11.21), `chocolateyInstall.ps1` is rewritten to always have CR/LF line endings instead of keeping the original line endings (LF). I ran `dos2unix` to transform that file back, so that `git diff` is not confused.