### PR TITLE
zoom - Fix inconsistent package name

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -6,7 +6,7 @@ $url = 'https://cdn.zoom.us/prod/5.12.8.10232/ZoomInstallerFull.msi'
 $url64 = 'https://cdn.zoom.us/prod/5.12.8.10232/x64/ZoomInstallerFull.msi'
 
 $packageArgs = @{
-  packageName    = 'zoom-client'
+  packageName    = $env:ChocolateyPackageName
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'msi'
   url            = $url


### PR DESCRIPTION
`zoom`'s install script has been passing an incorrect package name (`zoom-client`) to `Install-ChocolateyPackage` since v5.0.23168.0427, likely due to the script being derived from `zoom-client`. The package name is printed to the console during install, so this could potentially be misleading.

Changing `packageName` accordingly to reference the `ChocolateyPackageName` environment variable instead, to both correct the discrepancy and make this more resilient to any future code reuse or package name changes.
