### PR TITLE
[zoom] Add package parameters

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -5,14 +5,31 @@ $checksum64 = '3c5765f01836a9491b504c259bc6751a1704f545d0e644cb29c36af7bb9ba2cd'
 $url = 'https://cdn.zoom.us/prod/5.14.5.15287/ZoomInstallerFull.msi'
 $url64 = 'https://cdn.zoom.us/prod/5.14.5.15287/x64/ZoomInstallerFull.msi'
 
+$silentArgs = '/quiet /qn /norestart'
+
+$pp = Get-PackageParameters
+
+if ($pp['DisableRestartManager']) { $silentArgs += " MSIRestartManagerControl=Disable" }
+if ($pp['NoAutoUpdate']) { $silentArgs += " ZoomAutoUpdate=False" }
+else { $silentArgs += " ZoomAutoUpdate=True" }
+if ($pp['NoDesktopShortcut']) { $silentArgs += " zNoDesktopShortCut=True" }
+if ($pp['NoInstallIfRunning']) { 
+  if (Get-Process zoom -ea 0) {
+    Write-Warning "Exiting installation because Zoom is running and /NoInstallIfRunning was passed."
+    exit 1
+  }
+}
+if ($pp['SilentStart']) { $silentArgs += " zSilentStart=True" }
+if ($pp['SSOHost']) { $silentArgs += " zSSOHost=$(pp['SSOHost'])" }
+
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'msi'
   url            = $url
   url64          = $url64
-  silentArgs     = '/quiet /norestart ZoomAutoUpdate=True'
-  validExitCodes = @(0)
+  silentArgs     = $silentArgs
+  validExitCodes = @(0, 3010)
   softwareName   = 'zoom*'
   checksum       = $checksum
   checksum64     = $checksum64

--- a/automatic/zoom/zoom.nuspec
+++ b/automatic/zoom/zoom.nuspec
@@ -17,6 +17,20 @@
       solution offers the best video, audio, and wireless screen-sharing experience across Windows, Mac, iOS, Android, Blackberry, Linux, Zoom Rooms, and H.323/SIP
       room systems. Founded in 2011, Zoom's mission is to develop a people-centric cloud service that transforms the real-time collaboration experience and improves
       the quality and effectiveness of communications forever.
+
+      ### Package Specific
+      #### Package Parameters
+      The following package parameters can be set:
+
+      * `/DisableRestartManager` - Wait until the in-progress meeting is over before installing
+      * `/NoAutoUpdate` - Remove the Check for Updates option in the client
+      * `/NoDesktopShortcut` - Prevent the creation of a desktop shortcut on install or update
+      * `/NoInstallIfRunning` - Abort installation if Zoom is running
+      * `/SilentStart` - Automatically start client in the system tray after reboot
+      * `/SSOHost:` - Set the SSO URL
+
+      To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
+      To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
     </description>
     <summary>Zoom unifies cloud video conferencing, simple online meetings, group messaging, and a software-defined conference room solution into one easy-to-use platform.</summary>
     <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/zoom.png</iconUrl>


### PR DESCRIPTION
This adds a number of package parameters.   However, I'm have a couple of concerns about two of them which are the main driver of these changes.  Currently if zoom is updated with chocolatey the zoom client is automatically restarted, killing any active meetings, etc.  I want to avoid this as we are updating applications automatically in the background.

The issue with `DisableRestartManager` / `MSIRestartManagerControl=Disable` is that it doesn't really wait for a meeting/zoom to exit and seems to exit either with code 3010 or 1603, despite being successfully queued for installation the next time zoom is started.  This can leave the chocolatey version out of sync with the zoom version.  Accepting exit code 3010 as valid seems okay, but not 1603.

The issue with `NoInstallIfRunning` is that choco exits with an error code, despite doing exactly what we asked it to do.  But this is relatively minor and acceptable I think.

This also adds the `/qn` parameter, and options to disable the desktop shortcut and the update menu item.

Thoughts?