### PR TITLE
Switch Azure Storage Explorer to 64bit version

### DIFF
--- a/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
+++ b/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
@@ -9,9 +9,9 @@
     <title>Microsoft Azure Storage Explorer</title>
     <authors>Microsoft</authors>
     <projectUrl>http://storageexplorer.com/</projectUrl>
-    <copyright>Copyright 2006 Microsoft</copyright>
+    <copyright>Copyright 2023 Microsoft</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <tags>azure storage storageexplorer</tags>
+    <tags>azure microsoft storage explorer storageexplorer</tags>
     <summary>Easily work with Azure Storage - from any platform, anywhere.</summary>
     <description>Microsoft Azure Storage Explorer is a standalone app from Microsoft that allows you to easily work with Azure Storage data on Windows, macOS and Linux.</description>
     <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/microsoftazurestorageexplorer.png</iconUrl>

--- a/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
+++ b/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
@@ -11,13 +11,16 @@
     <projectUrl>http://storageexplorer.com/</projectUrl>
     <copyright>Copyright 2006 Microsoft</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <tags>azure</tags>
+    <tags>azure storage storageexplorer</tags>
     <summary>Easily work with Azure Storage - from any platform, anywhere.</summary>
     <description>Microsoft Azure Storage Explorer is a standalone app from Microsoft that allows you to easily work with Azure Storage data on Windows, macOS and Linux.</description>
     <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/microsoftazurestorageexplorer.png</iconUrl>
     <releaseNotes>https://docs.microsoft.com/en-us/azure/vs-azure-tools-storage-explorer-relnotes</releaseNotes>
     <docsUrl>https://docs.microsoft.com/en-us/azure/vs-azure-tools-storage-manage-with-storage-explorer?tabs=windows</docsUrl>
     <bugTrackerUrl>https://feedback.azure.com/forums/34192--general-feedback</bugTrackerUrl>
+    <dependencies>
+        <dependency id="dotnet-6.0-desktopruntime" version="6.0.13" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/microsoftazurestorageexplorer/update.ps1
+++ b/automatic/microsoftazurestorageexplorer/update.ps1
@@ -13,7 +13,7 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $file_name = 'StorageExplorer-windows-ia32.exe'
+    $file_name = 'StorageExplorer-windows-x64.exe'
     $windows_release = (Invoke-RestMethod $latestRelease).assets | Where-Object {$_.name -eq $file_name}
 
     $url = $windows_release.browser_download_url


### PR DESCRIPTION
Since v1.30.0 Azure Storage Explorer is only delivered as 64-bit version.
ref (https://github.com/microsoft/AzureStorageExplorer/releases/tag/v1.30.0)

Also it requires now a .NET 6 Runtime so added it as dependency