### PR TITLE
Fix broken Icon URLs

### DIFF
--- a/automatic/evernote/Evernote.nuspec
+++ b/automatic/evernote/Evernote.nuspec
@@ -9,7 +9,7 @@
     <owners>Peter Jahn</owners>
     <licenseUrl>http://evernote.com/eula/</licenseUrl>
     <projectUrl>http://evernote.com/evernote/</projectUrl>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/Evernote.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/Evernote.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>WRITE: From short lists to lengthy research, no matter what form your writing takes, Evernote keeps you focused on moving those ideas from inspiration to completion.
 

--- a/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
+++ b/automatic/microsoftazurestorageexplorer/microsoftazurestorageexplorer.nuspec
@@ -14,7 +14,7 @@
     <tags>azure microsoft storage explorer storageexplorer</tags>
     <summary>Easily work with Azure Storage - from any platform, anywhere.</summary>
     <description>Microsoft Azure Storage Explorer is a standalone app from Microsoft that allows you to easily work with Azure Storage data on Windows, macOS and Linux.</description>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/microsoftazurestorageexplorer.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/microsoftazurestorageexplorer.png</iconUrl>
     <releaseNotes>https://docs.microsoft.com/en-us/azure/vs-azure-tools-storage-explorer-relnotes</releaseNotes>
     <docsUrl>https://docs.microsoft.com/en-us/azure/vs-azure-tools-storage-manage-with-storage-explorer?tabs=windows</docsUrl>
     <bugTrackerUrl>https://feedback.azure.com/forums/34192--general-feedback</bugTrackerUrl>

--- a/automatic/zoom/zoom.nuspec
+++ b/automatic/zoom/zoom.nuspec
@@ -13,7 +13,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>zoom admin webinar webcam meeting</tags>
     <description>
-      Zoom unifies cloud video conferencing, simple online meetings, group messaging, and a software-defined conference room solution into one easy-to-use platform. 
+      Zoom unifies cloud video conferencing, simple online meetings, group messaging, and a software-defined conference room solution into one easy-to-use platform.
       solution offers the best video, audio, and wireless screen-sharing experience across Windows, Mac, iOS, Android, Blackberry, Linux, Zoom Rooms, and H.323/SIP
       room systems. Founded in 2011, Zoom's mission is to develop a people-centric cloud service that transforms the real-time collaboration experience and improves
       the quality and effectiveness of communications forever.
@@ -33,7 +33,7 @@
       To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
     </description>
     <summary>Zoom unifies cloud video conferencing, simple online meetings, group messaging, and a software-defined conference room solution into one easy-to-use platform.</summary>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/zoom.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/zoom.png</iconUrl>
     <docsUrl>https://support.zoom.us/hc/en-us</docsUrl>
     <licenseUrl>http://zoom.us/pricing</licenseUrl>
     <bugTrackerUrl>https://support.zoom.us/hc/en-us/requests/new</bugTrackerUrl>

--- a/manual/directx/directx.nuspec
+++ b/manual/directx/directx.nuspec
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>DirectX is a collection of APIs for handling tasks related to games and videos.</description>
     <tags>microsoft directx games gaming opengl</tags>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/Directx9.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/Directx9.png</iconUrl>
   </metadata>
   <files>
     <file src="tools\**" />

--- a/manual/ringcentral-classic/ringcentral-classic.nuspec
+++ b/manual/ringcentral-classic/ringcentral-classic.nuspec
@@ -9,7 +9,7 @@
     <owners>Mike Cole</owners>
     <licenseUrl>https://www.ringcentral.com/legal/eulatos.html</licenseUrl>
     <projectUrl>https://www.ringcentral.com/teams/overview.html</projectUrl>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/ringcentral-classic.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/ringcentral-classic.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>**RingCentral Classic** gives you a more unified experience by allowing you to collaborate with your colleagues in one place, from anywhere and on any device. It is suitable for knowledge workers and for all Users alike, who want to maximize their productivity and minimize the number of open apps as they work.</description>
     <summary>Free team messaging, video meetings, task management, and more—together in one app.</summary>

--- a/manual/steam-client/steam-client.nuspec
+++ b/manual/steam-client/steam-client.nuspec
@@ -9,7 +9,7 @@
     <owners>Mike Cole</owners>
     <licenseUrl>http://store.steampowered.com/subscriber_agreement/</licenseUrl>
     <projectUrl>http://store.steampowered.com/</projectUrl>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/steam-client.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/steam-client.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
     Steam is a digital distribution platform developed by Valve Corporation for purchasing and playing video games. Steam offers digital rights management, matchmaking servers, video streaming, and social networking services.

--- a/manual/whocrashed/whocrashed.nuspec
+++ b/manual/whocrashed/whocrashed.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>http://www.resplendence.com/licensing</licenseUrl>
     <projectUrl>http://www.resplendence.com/whocrashed</projectUrl>
-    <iconUrl>https://cdn.staticaly.com/gh/mikecole/chocolatey-packages/master/icons/whocrashed.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/mikecole/chocolatey-packages/master/icons/whocrashed.png</iconUrl>
     <description>
         #### Note:
         The Free edition is only available for home use. Business users must purchase a professional license.
@@ -23,10 +23,10 @@
     <copyright>Resplendence Software Projects Sp.</copyright>
     <bugTrackerUrl>https://www.resplendence.com/support</bugTrackerUrl>
     <docsUrl>https://www.resplendence.com/whocrashed.htm</docsUrl>
-    <tags>Crash Dump Debugging</tags>  
-    <dependencies></dependencies>     
+    <tags>Crash Dump Debugging</tags>
+    <dependencies></dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
-  </files>   
+  </files>
 </package>


### PR DESCRIPTION
Switch the iconUrl from https://cdn.staticaly.com to https://cdn.statically.io after https://cdn.staticaly.com seem to be not rechable anymore.