### PR TITLE
zoom: check for existing install

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -37,4 +37,13 @@ $packageArgs = @{
   checksumType64 = 'sha256'
 }
 
-Install-ChocolateyPackage @packageArgs
+$ZoomPath = Join-Path -Path $Env:ProgramFiles -ChildPath 'Zoom\bin\Zoom.exe'
+
+[Version]$InstalledVersion = (Get-ItemProperty -Path $ZoomPath -ErrorAction:Ignore).VersionInfo.FileVersionRaw
+
+$UpdateNeeded = $InstalledVersion -lt [Version]$Env:ChocolateyPackageVersion
+
+if ($UpdateNeeded -or $Env:ChocolateyForce)
+{
+  Install-ChocolateyPackage @packageArgs
+}


### PR DESCRIPTION
 - run installer only if needed or forced

--
Check to see if there is an existing version of zoom installed in the default installation path and grab its version information.  Only attempt to run the installer If the version already installed is out of date, or if the end-user passes the `--force` parameter.

If the package is run against a machine that already has this or a later version of the software installed, the package install will needlessly fail. Instead of allowing the package to fail, check to see if the software is already present an up-to-date (updated outside of chocolatey, updated via third-party patch, built-in autoupdater).

This will allow new or existing chocolatey users to transition to this package without causing errors, and will also prevent errors if the browser was already updated.  Also would be beneficial to C4B users who have static, internalized versions of the installer.
