### PR TITLE
zoom: Remove typo character

### DIFF
--- a/automatic/zoom/tools/chocolateyInstall.ps1
+++ b/automatic/zoom/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop'
-ß
+
 $checksum64 = '9e7476d9ddeb844a7717a88f2559dda37693772fdd72b39b7091a33b17343793'
 
 


### PR DESCRIPTION
Typo on line 2 found its way in somewhere between my testing and commit. The typo caused the chocolatey automatic validation testing to fail.